### PR TITLE
catch infinite loop in summary_qa.create_splits() 

### DIFF
--- a/summary_qg.py
+++ b/summary_qg.py
@@ -31,7 +31,7 @@ def create_splits(text, tokenizer):
         if all(s < 512 for s in splits_len):
             break
         elif len(sents) == 1:
-            print(f'WARNING: sentence too long ({len(enc[0])} tokens), skipped')
+            print(f'WARNING: sentence too long ({len(enc_sents_len[0])} tokens), skipped')
             return []
 
     return [' '.join(sents[s:e]) for (s,e) in splits]

--- a/summary_qg.py
+++ b/summary_qg.py
@@ -30,6 +30,9 @@ def create_splits(text, tokenizer):
         splits_len = [sum(enc_sents_len[s:e]) + 1 for (s,e) in splits]
         if all(s < 512 for s in splits_len):
             break
+        elif len(sents) == 1:
+            print(f'WARNING: sentence too long ({len(enc[0])} tokens), skipped')
+            return []
 
     return [' '.join(sents[s:e]) for (s,e) in splits]
 


### PR DESCRIPTION
There was an edge case infinite loop before, when there is a sentence >= 512 tokens. There is no way to split this sentence further, so it loops forever.

This `elif` is a quick fix -- it will just not process this text, returning `[]`. The assumption is that such a long sentence is probably "unnatural" text, so we don't use it.